### PR TITLE
Fixed breaking failure endpoint due to csrf token

### DIFF
--- a/app/controllers/concerns/bpluser/omniauth_callbacks.rb
+++ b/app/controllers/concerns/bpluser/omniauth_callbacks.rb
@@ -7,7 +7,7 @@ module Bpluser
     included do
       include InstanceMethods
 
-      skip_before_action :verify_authenticity_token, only: :polaris
+      skip_before_action :verify_authenticity_token, only: [:polaris, :failure]
     end
 
     module InstanceMethods

--- a/bpluser.gemspec
+++ b/bpluser.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'devise', '~> 4.8.1'
   s.add_dependency 'devise-guests', '~> 0.8.1'
   s.add_dependency 'omniauth', '~> 2.1'
-  s.add_dependency 'omniauth-polaris', '~> 1.1'
+  s.add_dependency 'omniauth-polaris', '~> 1.1.1'
   s.add_dependency 'omniauth-rails_csrf_protection', '~> 1.0'
   s.add_dependency 'rails', '~> 6.0.6'
 

--- a/lib/bpluser/version.rb
+++ b/lib/bpluser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bpluser
-  VERSION = '0.2.0.2'
+  VERSION = '0.2.0.3'
 end


### PR DESCRIPTION
- omniauth Failure endpoint was breaking due to a non needed csrf token